### PR TITLE
Bump `keyvalues-parser` to `v0.2.0`

### DIFF
--- a/keyvalues-parser/Cargo.toml
+++ b/keyvalues-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyvalues-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.61"


### PR DESCRIPTION
Next up should be pushing a tag to start the release process. We'll see if everything still works after all this time :crossed_fingers: 