### PR TITLE
Bump `keyvalues-serde` to `v0.2.0`

### DIFF
--- a/keyvalues-serde/Cargo.toml
+++ b/keyvalues-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyvalues-serde"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.61"
@@ -12,7 +12,7 @@ homepage = "https://github.com/CosmicHorrorDev/vdf-rs"
 repository = "https://github.com/CosmicHorrorDev/vdf-rs"
 
 [dependencies]
-keyvalues-parser = { path = "../keyvalues-parser" }
+keyvalues-parser = { path = "../keyvalues-parser", version = "0.2.0" }
 serde = "1.0.190"
 # TODO: drop this
 thiserror = "1.0.50"


### PR DESCRIPTION
Just bumps `keyvalues-serde` in turn