### PR TITLE
Don't panic when serializing an invalid tokenstream

### DIFF
--- a/keyvalues-serde/src/ser.rs
+++ b/keyvalues-serde/src/ser.rs
@@ -79,7 +79,7 @@ where
         }
     }
 
-    let vdf = Vdf::from(&serializer.tokens);
+    let vdf = Vdf::try_from(&serializer.tokens)?;
     write!(writer, "{}", vdf)?;
 
     Ok(())

--- a/keyvalues-serde/src/tokens/tests.rs
+++ b/keyvalues-serde/src/tokens/tests.rs
@@ -1,11 +1,14 @@
-use keyvalues_parser::{Obj, Value, Vdf};
-
 use std::borrow::Cow;
 
-use crate::tokens::{
-    naive::{NaiveToken, NaiveTokenStream},
-    Token, TokenStream,
+use crate::{
+    tokens::{
+        naive::{NaiveToken, NaiveTokenStream},
+        Token, TokenStream,
+    },
+    Error,
 };
+
+use keyvalues_parser::{Obj, Value, Vdf};
 
 // "outer"
 // {
@@ -53,12 +56,11 @@ fn vdf_from_token_stream_basics() {
         }
     };
 
-    let actual = Vdf::from(&naive_token_stream);
+    let actual = Vdf::try_from(&naive_token_stream).unwrap();
     assert_eq!(actual, ideal);
 }
 
 #[test]
-#[should_panic]
 fn invalid_vdf_nested_seq() {
     let naive_token_stream = NaiveTokenStream(vec![
         NaiveToken::str("outer"),
@@ -72,11 +74,11 @@ fn invalid_vdf_nested_seq() {
         NaiveToken::ObjEnd,
     ]);
 
-    let _ = Vdf::from(&naive_token_stream);
+    let err = Vdf::try_from(&naive_token_stream).unwrap_err();
+    assert!(matches!(err, Error::ExpectedSomeNonSeqValue), "{err:?}");
 }
 
 #[test]
-#[should_panic]
 fn invalid_vdf_obj_key() {
     let naive_token_stream = NaiveTokenStream(vec![
         NaiveToken::str("outer"),
@@ -86,11 +88,11 @@ fn invalid_vdf_obj_key() {
         NaiveToken::ObjEnd,
     ]);
 
-    let _ = Vdf::from(&naive_token_stream);
+    // TODO: clean up error type, so we can compare
+    let _err = Vdf::try_from(&naive_token_stream).unwrap_err();
 }
 
 #[test]
-#[should_panic]
 fn invalid_vdf_seq_key() {
     let naive_token_stream = NaiveTokenStream(vec![
         NaiveToken::str("outer"),
@@ -100,7 +102,8 @@ fn invalid_vdf_seq_key() {
         NaiveToken::ObjEnd,
     ]);
 
-    let _ = Vdf::from(&naive_token_stream);
+    // TODO: clean up error type, so we can compare
+    let _err = Vdf::try_from(&naive_token_stream).unwrap_err();
 }
 
 #[test]

--- a/keyvalues-serde/tests/invalid_types.rs
+++ b/keyvalues-serde/tests/invalid_types.rs
@@ -1,4 +1,6 @@
-use keyvalues_serde::{from_str, Error, Result};
+use std::collections::BTreeMap;
+
+use keyvalues_serde::{from_str, to_string, Error, Result};
 use serde::Deserialize;
 
 mod utils;
@@ -37,4 +39,10 @@ fn invalid_types() {
 
     let unit_struct: Result<Container<Unit>> = from_str(DUMMY_TEXT);
     check!(unit_struct, "Unit Struct");
+}
+
+#[test]
+fn missing_top_level_key() {
+    // TODO: clean up error type, so we can compare
+    let _err = to_string(&BTreeMap::<(), ()>::new()).unwrap_err();
 }


### PR DESCRIPTION
Fixes #45

There are some lingering notes where I've noticed that the `Error` type is pretty messy, but other than that the changes are very straightforward