### PR TITLE
chore: Explicity pass codecov token as now required

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,3 +19,5 @@ jobs:
         run: cargo llvm-cov --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+comment: false
+github_checks: false
+coverage:
+  status:
+    patch: false


### PR DESCRIPTION
Seems like we now have to explicitly pass the `CODECOV_TOKEN` now