### PR TITLE
chore: Lower `Cargo.toml` msrv

### DIFF
--- a/keyvalues-parser/Cargo.toml
+++ b/keyvalues-parser/Cargo.toml
@@ -3,7 +3,7 @@ name = "keyvalues-parser"
 version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.70"
+rust-version = "1.64.0"
 
 authors = ["Cosmic <CosmicHorrorDev@pm.me>"]
 keywords = ["keyvalues", "vdf", "steam", "parser"]

--- a/keyvalues-serde/Cargo.toml
+++ b/keyvalues-serde/Cargo.toml
@@ -3,7 +3,7 @@ name = "keyvalues-serde"
 version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.70"
+rust-version = "1.64.0"
 
 authors = ["Cosmic <CosmicHorrorDev@pm.me>"]
 keywords = ["keyvalues", "vdf", "steam", "serde"]


### PR DESCRIPTION
We test higher in CI because dealing with the old crates.io git index, but we really compile with lower

Checking MSRV compilation is part of the release checklist, so ideally we should catch any breakage