### PR TITLE
Expose raw VDF parsing as from_str_raw

### DIFF
--- a/keyvalues-serde/src/de/mod.rs
+++ b/keyvalues-serde/src/de/mod.rs
@@ -45,6 +45,17 @@ pub fn from_str_with_key<'a, T: Deserialize<'a>>(s: &'a str) -> Result<(T, Key<'
     from_vdf_with_key(vdf)
 }
 
+/// Attempts to deserialize a string of VDF text to some type T, without parsing escape sequences
+pub fn from_str_raw<'a, T: Deserialize<'a>>(s: &'a str) -> Result<T> {
+    from_str_raw_with_key(s).map(|(t, _)| t)
+}
+
+/// The same as [`raw_from_str()`], but also returns the top level VDF key
+pub fn from_str_raw_with_key<'a, T: Deserialize<'a>>(s: &'a str) -> Result<(T, Key<'a>)> {
+    let vdf = Vdf::parse_raw(s)?;
+    from_vdf_with_key(vdf)
+}
+
 pub fn from_vdf<'a, T: Deserialize<'a>>(vdf: Vdf<'a>) -> Result<T> {
     from_vdf_with_key(vdf).map(|(t, _)| t)
 }

--- a/keyvalues-serde/src/lib.rs
+++ b/keyvalues-serde/src/lib.rs
@@ -17,8 +17,8 @@ pub use keyvalues_parser as parser;
 
 #[doc(inline)]
 pub use de::{
-    from_reader, from_reader_with_key, from_str, from_str_with_key, from_vdf, from_vdf_with_key,
-    Deserializer,
+    from_reader, from_reader_with_key, from_str, from_str_raw, from_str_raw_with_key,
+    from_str_with_key, from_vdf, from_vdf_with_key, Deserializer,
 };
 #[doc(inline)]
 pub use error::{Error, Result};

--- a/keyvalues-serde/tests/assets/raw_string.vdf
+++ b/keyvalues-serde/tests/assets/raw_string.vdf
@@ -1,0 +1,4 @@
+"RawString"
+{
+    "str\key" "str\a\bvalue"
+}

--- a/keyvalues-serde/tests/special_cases/mod.rs
+++ b/keyvalues-serde/tests/special_cases/mod.rs
@@ -4,8 +4,8 @@ use crate::utils::{read_asset_file, test_vdf_deserialization, BoxedResult, Conta
 
 use insta::{assert_debug_snapshot, assert_snapshot};
 use keyvalues_serde::{
-    from_str, from_str_with_key, to_string, to_string_with_key, to_writer, to_writer_with_key,
-    Error,
+    from_str, from_str_raw, from_str_with_key, to_string, to_string_with_key, to_writer,
+    to_writer_with_key, Error,
 };
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
@@ -137,6 +137,21 @@ fn borrowed_escaped_string() -> BoxedResult<()> {
 
     assert_eq!(vdf, Container::new(Cow::from("tab\tseparated")));
     Ok(())
+}
+
+#[test]
+fn raw_escaped_string() -> BoxedResult<()> {
+    let vdf_text = read_asset_file("raw_string.vdf")?;
+    let vdf: RawString = from_str_raw(&vdf_text)?;
+
+    assert_eq!(vdf.unescaped_str_key, vec!["str\\a\\bvalue"]);
+    Ok(())
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+struct RawString {
+    #[serde(rename = "str\\key")]
+    pub unescaped_str_key: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
This just exposes the `parse_raw` functionality of `keyvalues-parser` from `keyvalues-serde`. 