### PR TITLE
fix(serde): Allow for maps where we normally see structs

### DIFF
--- a/keyvalues-serde/src/tokens/tests.rs
+++ b/keyvalues-serde/src/tokens/tests.rs
@@ -79,20 +79,6 @@ fn invalid_vdf_nested_seq() {
 }
 
 #[test]
-fn invalid_vdf_obj_key() {
-    let naive_token_stream = NaiveTokenStream(vec![
-        NaiveToken::str("outer"),
-        NaiveToken::ObjBegin,
-        NaiveToken::ObjBegin,
-        NaiveToken::ObjEnd,
-        NaiveToken::ObjEnd,
-    ]);
-
-    // TODO: clean up error type, so we can compare
-    let _err = Vdf::try_from(&naive_token_stream).unwrap_err();
-}
-
-#[test]
 fn invalid_vdf_seq_key() {
     let naive_token_stream = NaiveTokenStream(vec![
         NaiveToken::str("outer"),

--- a/keyvalues-serde/tests/malformed/mod.rs
+++ b/keyvalues-serde/tests/malformed/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-};
+use std::{collections::HashMap, fmt};
 
 use crate::utils::{read_asset_file, BoxedResult, Container};
 
@@ -42,12 +39,6 @@ test_snapshot_de!(
 );
 
 test_snapshot_de!(obj_when_wanting_str, Container<String>, "obj_container.vdf");
-
-#[test]
-fn missing_top_level_key() {
-    // TODO: clean up error type, so we can compare
-    let _err = to_string(&BTreeMap::<(), ()>::new()).unwrap_err();
-}
 
 #[test]
 fn incorrect_seq_length() -> BoxedResult<()> {

--- a/keyvalues-serde/tests/regression_tests/mod.rs
+++ b/keyvalues-serde/tests/regression_tests/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -33,4 +33,23 @@ fn enum_key() {
     let empty = Empty {};
     let expected = BTreeMap::from([(Enum::Foo, empty), (Enum::Bar, empty)]);
     assert_eq!(outer.enum_keys, expected);
+}
+
+#[test]
+fn flatten() {
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Foo {
+        a: i32,
+        // This, otherwise innocuous looking, `flatten` changes this type to be treated as what it's
+        // being flattened to. In this case from a struct to a map
+        #[serde(flatten)]
+        other: HashMap<String, String>,
+    }
+
+    let foo = Foo {
+        a: 0,
+        other: HashMap::new(),
+    };
+    let serialized = keyvalues_serde::to_string(&foo).unwrap();
+    insta::assert_snapshot!(serialized);
 }

--- a/keyvalues-serde/tests/regression_tests/snapshots/stub__regression_tests__flatten.snap
+++ b/keyvalues-serde/tests/regression_tests/snapshots/stub__regression_tests__flatten.snap
@@ -1,0 +1,8 @@
+---
+source: keyvalues-serde/tests/regression_tests/mod.rs
+expression: serialized
+---
+""
+{
+	"a"	"0"
+}


### PR DESCRIPTION
Resolves #52 

Having `#[serde(flatten)]` on a field of a struct containing a map type will cause `serde` to serialize the whole type as a map instead of a struct. Previously we wouldn't allow for maps in all of the places that we would normally expect structs, but this kind of functionality makes that distinction moot. Instead we implicitly set an empty key when we see the start of an object while looking for a key