### PR TITLE
release: Update `keyvalues-serde` version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "keyvalues-serde"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "divan",
  "insta",

--- a/keyvalues-serde/Cargo.toml
+++ b/keyvalues-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyvalues-serde"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.64.0"


### PR DESCRIPTION
No need to hold up a `keyvalues-serde` release while waiting for the `keyvalues-parser` re-write