### PR TITLE
fix: avoid recursion in string parsing

### DIFF
--- a/keyvalues-parser/src/grammars/escaped.pest
+++ b/keyvalues-parser/src/grammars/escaped.pest
@@ -19,8 +19,11 @@ value = _{ quoted_string | obj | unquoted_string }
 obj = { "{" ~ pairs ~ "}" }
 
 quoted_string = ${ "\"" ~ quoted_inner ~ "\"" }
-quoted_inner = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ quoted_inner)? }
-escape = @{ "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
+quoted_inner = @{ char* }
+char = {
+    !("\"" | "\\") ~ ANY
+    | "\\" ~ ("\"" | "\\" | "n" | "r" | "t")
+}
 
 unquoted_string = @{ unquoted_char+ }
 // The wiki page just states that an unquoted string ends with ", {, }, or any

--- a/keyvalues-parser/tests/regressions/mod.rs
+++ b/keyvalues-parser/tests/regressions/mod.rs
@@ -1,6 +1,22 @@
+use std::iter;
+
 use keyvalues_parser::Vdf;
 
 mod fuzzer;
+
+#[test]
+fn issue_54() {
+    // Generates strings e.g. `lots_of_escaped(2)` gives `"" "\"\""`
+    fn lots_of_escapes(num_escaped: usize) -> String {
+        iter::once("\"\" \"")
+            .chain(iter::repeat("\\\"").take(num_escaped))
+            .chain(iter::once("\""))
+            .collect()
+    }
+
+    let vdf_text = lots_of_escapes(20_000);
+    Vdf::parse(&vdf_text).unwrap();
+}
 
 #[test]
 fn raw_no_newline() {


### PR DESCRIPTION
This also fixes #54 while still using pest :tada: