### PR TITLE
refactor: commit generated parser code over deriving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,8 +161,11 @@ dependencies = [
  "divan",
  "insta",
  "pest",
- "pest_derive",
+ "pest_generator",
  "pretty_assertions",
+ "prettyplease",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -212,16 +215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest_derive"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc58706f770acb1dbd0973e6530a3cff4746fb721207feb3a8a6064cd0b6c663"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
 name = "pest_generator"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +248,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]

--- a/keyvalues-parser/Cargo.toml
+++ b/keyvalues-parser/Cargo.toml
@@ -13,14 +13,19 @@ homepage = "https://github.com/CosmicHorrorDev/vdf-rs/tree/main/keyvalues-parser
 repository = "https://github.com/CosmicHorrorDev/vdf-rs"
 
 [dependencies]
-# TODO: switch parsing to `nom`
 pest = "2.7"
-pest_derive = "2.7"
 
 [dev-dependencies]
 divan.workspace = true
 insta.workspace = true
+pest_generator = "2.7.15"
 pretty_assertions.workspace = true
+prettyplease = "0.2.37"
+quote = "1.0.40"
+
+[dev-dependencies.syn]
+version = "2.0.106"
+features = ["extra-traits"]
 
 [[bench]]
 name = "parser"

--- a/keyvalues-parser/src/text/parse/escaped.rs
+++ b/keyvalues-parser/src/text/parse/escaped.rs
@@ -1,0 +1,549 @@
+// !!GENERATED CODE!! DO NOT EDIT MANUALLY. edit through the `grammar_generator` tests
+use super::*;
+use pest::Parser as _;
+pub type PestError = pest::error::Error<Rule>;
+struct Parser;
+crate::common_parsing!(Parser, Rule, true);
+#[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Rule {
+    ///End-of-input
+    EOI,
+    r#WHITESPACE,
+    r#COMMENT,
+    r#vdf,
+    r#base_macro,
+    r#quoted_raw_string,
+    r#quoted_raw_inner,
+    r#pairs,
+    r#pair,
+    r#key,
+    r#value,
+    r#obj,
+    r#quoted_string,
+    r#quoted_inner,
+    r#char,
+    r#unquoted_string,
+    r#unquoted_char,
+}
+impl Rule {
+    pub fn all_rules() -> &'static [Rule] {
+        &[
+            Rule::r#WHITESPACE,
+            Rule::r#COMMENT,
+            Rule::r#vdf,
+            Rule::r#base_macro,
+            Rule::r#quoted_raw_string,
+            Rule::r#quoted_raw_inner,
+            Rule::r#pairs,
+            Rule::r#pair,
+            Rule::r#key,
+            Rule::r#value,
+            Rule::r#obj,
+            Rule::r#quoted_string,
+            Rule::r#quoted_inner,
+            Rule::r#char,
+            Rule::r#unquoted_string,
+            Rule::r#unquoted_char,
+        ]
+    }
+}
+#[allow(clippy::all)]
+impl ::pest::Parser<Rule> for Parser {
+    fn parse<'i>(
+        rule: Rule,
+        input: &'i str,
+    ) -> ::std::result::Result<
+        ::pest::iterators::Pairs<'i, Rule>,
+        ::pest::error::Error<Rule>,
+    > {
+        mod rules {
+            #![allow(clippy::upper_case_acronyms)]
+            pub mod hidden {
+                use super::super::Rule;
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn skip(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    if state.atomicity() == ::pest::Atomicity::NonAtomic {
+                        state
+                            .sequence(|state| {
+                                state
+                                    .repeat(|state| super::visible::WHITESPACE(state))
+                                    .and_then(|state| {
+                                        state
+                                            .repeat(|state| {
+                                                state
+                                                    .sequence(|state| {
+                                                        super::visible::COMMENT(state)
+                                                            .and_then(|state| {
+                                                                state.repeat(|state| super::visible::WHITESPACE(state))
+                                                            })
+                                                    })
+                                            })
+                                    })
+                            })
+                    } else {
+                        Ok(state)
+                    }
+                }
+            }
+            pub mod visible {
+                use super::super::Rule;
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#WHITESPACE(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::Atomic,
+                            |state| {
+                                state
+                                    .match_string(" ")
+                                    .or_else(|state| { state.match_string("\t") })
+                                    .or_else(|state| { state.match_string("\r") })
+                                    .or_else(|state| { state.match_string("\n") })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#COMMENT(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::Atomic,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .match_string("//")
+                                            .and_then(|state| {
+                                                state
+                                                    .repeat(|state| {
+                                                        state
+                                                            .sequence(|state| {
+                                                                state
+                                                                    .lookahead(false, |state| { state.match_string("\n") })
+                                                                    .and_then(|state| { self::r#ANY(state) })
+                                                            })
+                                                    })
+                                            })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#vdf(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .sequence(|state| {
+                            self::r#SOI(state)
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| {
+                                    state
+                                        .sequence(|state| {
+                                            state
+                                                .optional(|state| {
+                                                    self::r#base_macro(state)
+                                                        .and_then(|state| {
+                                                            state
+                                                                .repeat(|state| {
+                                                                    state
+                                                                        .sequence(|state| {
+                                                                            super::hidden::skip(state)
+                                                                                .and_then(|state| { self::r#base_macro(state) })
+                                                                        })
+                                                                })
+                                                        })
+                                                })
+                                        })
+                                })
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| { self::r#pair(state) })
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| {
+                                    state.optional(|state| { state.match_string("\0") })
+                                })
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| { self::r#EOI(state) })
+                        })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#base_macro(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#base_macro,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .match_string("#base")
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| {
+                                                self::r#quoted_raw_string(state)
+                                                    .or_else(|state| { self::r#unquoted_string(state) })
+                                            })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#quoted_raw_string(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::CompoundAtomic,
+                            |state| {
+                                state
+                                    .rule(
+                                        Rule::r#quoted_raw_string,
+                                        |state| {
+                                            state
+                                                .sequence(|state| {
+                                                    state
+                                                        .match_string("\"")
+                                                        .and_then(|state| { self::r#quoted_raw_inner(state) })
+                                                        .and_then(|state| { state.match_string("\"") })
+                                                })
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#quoted_raw_inner(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#quoted_raw_inner,
+                            |state| {
+                                state
+                                    .atomic(
+                                        ::pest::Atomicity::Atomic,
+                                        |state| {
+                                            let strings = ["\""];
+                                            state.skip_until(&strings)
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#pairs(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .sequence(|state| {
+                            state
+                                .optional(|state| {
+                                    self::r#pair(state)
+                                        .and_then(|state| {
+                                            state
+                                                .repeat(|state| {
+                                                    state
+                                                        .sequence(|state| {
+                                                            super::hidden::skip(state)
+                                                                .and_then(|state| { self::r#pair(state) })
+                                                        })
+                                                })
+                                        })
+                                })
+                        })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#pair(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#pair,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        self::r#key(state)
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { self::r#value(state) })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#key(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    self::r#quoted_string(state)
+                        .or_else(|state| { self::r#unquoted_string(state) })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#value(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    self::r#quoted_string(state)
+                        .or_else(|state| { self::r#obj(state) })
+                        .or_else(|state| { self::r#unquoted_string(state) })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#obj(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#obj,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .match_string("{")
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { self::r#pairs(state) })
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { state.match_string("}") })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#quoted_string(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::CompoundAtomic,
+                            |state| {
+                                state
+                                    .rule(
+                                        Rule::r#quoted_string,
+                                        |state| {
+                                            state
+                                                .sequence(|state| {
+                                                    state
+                                                        .match_string("\"")
+                                                        .and_then(|state| { self::r#quoted_inner(state) })
+                                                        .and_then(|state| { state.match_string("\"") })
+                                                })
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#quoted_inner(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#quoted_inner,
+                            |state| {
+                                state
+                                    .atomic(
+                                        ::pest::Atomicity::Atomic,
+                                        |state| { state.repeat(|state| { self::r#char(state) }) },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#char(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#char,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .lookahead(
+                                                false,
+                                                |state| {
+                                                    state
+                                                        .match_string("\"")
+                                                        .or_else(|state| { state.match_string("\\") })
+                                                },
+                                            )
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { self::r#ANY(state) })
+                                    })
+                                    .or_else(|state| {
+                                        state
+                                            .sequence(|state| {
+                                                state
+                                                    .match_string("\\")
+                                                    .and_then(|state| { super::hidden::skip(state) })
+                                                    .and_then(|state| {
+                                                        state
+                                                            .match_string("\"")
+                                                            .or_else(|state| { state.match_string("\\") })
+                                                            .or_else(|state| { state.match_string("n") })
+                                                            .or_else(|state| { state.match_string("r") })
+                                                            .or_else(|state| { state.match_string("t") })
+                                                    })
+                                            })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#unquoted_string(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#unquoted_string,
+                            |state| {
+                                state
+                                    .atomic(
+                                        ::pest::Atomicity::Atomic,
+                                        |state| {
+                                            state
+                                                .sequence(|state| {
+                                                    self::r#unquoted_char(state)
+                                                        .and_then(|state| {
+                                                            state.repeat(|state| { self::r#unquoted_char(state) })
+                                                        })
+                                                })
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#unquoted_char(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#unquoted_char,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .lookahead(
+                                                false,
+                                                |state| {
+                                                    state
+                                                        .match_string("\"")
+                                                        .or_else(|state| { state.match_string("{") })
+                                                        .or_else(|state| { state.match_string("}") })
+                                                        .or_else(|state| { self::r#WHITESPACE(state) })
+                                                },
+                                            )
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { self::r#ANY(state) })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn ANY(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state.skip(1)
+                }
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn EOI(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state.rule(Rule::EOI, |state| state.end_of_input())
+                }
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn SOI(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state.start_of_input()
+                }
+            }
+            pub use self::visible::*;
+        }
+        ::pest::state(
+            input,
+            |state| {
+                match rule {
+                    Rule::r#WHITESPACE => rules::r#WHITESPACE(state),
+                    Rule::r#COMMENT => rules::r#COMMENT(state),
+                    Rule::r#vdf => rules::r#vdf(state),
+                    Rule::r#base_macro => rules::r#base_macro(state),
+                    Rule::r#quoted_raw_string => rules::r#quoted_raw_string(state),
+                    Rule::r#quoted_raw_inner => rules::r#quoted_raw_inner(state),
+                    Rule::r#pairs => rules::r#pairs(state),
+                    Rule::r#pair => rules::r#pair(state),
+                    Rule::r#key => rules::r#key(state),
+                    Rule::r#value => rules::r#value(state),
+                    Rule::r#obj => rules::r#obj(state),
+                    Rule::r#quoted_string => rules::r#quoted_string(state),
+                    Rule::r#quoted_inner => rules::r#quoted_inner(state),
+                    Rule::r#char => rules::r#char(state),
+                    Rule::r#unquoted_string => rules::r#unquoted_string(state),
+                    Rule::r#unquoted_char => rules::r#unquoted_char(state),
+                    Rule::EOI => rules::EOI(state),
+                }
+            },
+        )
+    }
+}

--- a/keyvalues-parser/src/text/parse/raw.rs
+++ b/keyvalues-parser/src/text/parse/raw.rs
@@ -1,0 +1,480 @@
+// !!GENERATED CODE!! DO NOT EDIT MANUALLY. edit through the `grammar_generator` tests
+use super::*;
+use pest::Parser as _;
+pub type PestError = pest::error::Error<Rule>;
+struct Parser;
+crate::common_parsing!(Parser, Rule, false);
+#[allow(dead_code, non_camel_case_types, clippy::upper_case_acronyms)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Rule {
+    ///End-of-input
+    EOI,
+    r#WHITESPACE,
+    r#COMMENT,
+    r#vdf,
+    r#base_macro,
+    r#quoted_raw_string,
+    r#pairs,
+    r#pair,
+    r#key,
+    r#value,
+    r#obj,
+    r#quoted_string,
+    r#quoted_inner,
+    r#unquoted_string,
+    r#unquoted_char,
+}
+impl Rule {
+    pub fn all_rules() -> &'static [Rule] {
+        &[
+            Rule::r#WHITESPACE,
+            Rule::r#COMMENT,
+            Rule::r#vdf,
+            Rule::r#base_macro,
+            Rule::r#quoted_raw_string,
+            Rule::r#pairs,
+            Rule::r#pair,
+            Rule::r#key,
+            Rule::r#value,
+            Rule::r#obj,
+            Rule::r#quoted_string,
+            Rule::r#quoted_inner,
+            Rule::r#unquoted_string,
+            Rule::r#unquoted_char,
+        ]
+    }
+}
+#[allow(clippy::all)]
+impl ::pest::Parser<Rule> for Parser {
+    fn parse<'i>(
+        rule: Rule,
+        input: &'i str,
+    ) -> ::std::result::Result<
+        ::pest::iterators::Pairs<'i, Rule>,
+        ::pest::error::Error<Rule>,
+    > {
+        mod rules {
+            #![allow(clippy::upper_case_acronyms)]
+            pub mod hidden {
+                use super::super::Rule;
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn skip(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    if state.atomicity() == ::pest::Atomicity::NonAtomic {
+                        state
+                            .sequence(|state| {
+                                state
+                                    .repeat(|state| super::visible::WHITESPACE(state))
+                                    .and_then(|state| {
+                                        state
+                                            .repeat(|state| {
+                                                state
+                                                    .sequence(|state| {
+                                                        super::visible::COMMENT(state)
+                                                            .and_then(|state| {
+                                                                state.repeat(|state| super::visible::WHITESPACE(state))
+                                                            })
+                                                    })
+                                            })
+                                    })
+                            })
+                    } else {
+                        Ok(state)
+                    }
+                }
+            }
+            pub mod visible {
+                use super::super::Rule;
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#WHITESPACE(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::Atomic,
+                            |state| {
+                                state
+                                    .match_string(" ")
+                                    .or_else(|state| { state.match_string("\t") })
+                                    .or_else(|state| { state.match_string("\r") })
+                                    .or_else(|state| { state.match_string("\n") })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#COMMENT(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::Atomic,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .match_string("//")
+                                            .and_then(|state| {
+                                                state
+                                                    .repeat(|state| {
+                                                        state
+                                                            .sequence(|state| {
+                                                                state
+                                                                    .lookahead(false, |state| { state.match_string("\n") })
+                                                                    .and_then(|state| { self::r#ANY(state) })
+                                                            })
+                                                    })
+                                            })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#vdf(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .sequence(|state| {
+                            self::r#SOI(state)
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| {
+                                    state
+                                        .sequence(|state| {
+                                            state
+                                                .optional(|state| {
+                                                    self::r#base_macro(state)
+                                                        .and_then(|state| {
+                                                            state
+                                                                .repeat(|state| {
+                                                                    state
+                                                                        .sequence(|state| {
+                                                                            super::hidden::skip(state)
+                                                                                .and_then(|state| { self::r#base_macro(state) })
+                                                                        })
+                                                                })
+                                                        })
+                                                })
+                                        })
+                                })
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| { self::r#pair(state) })
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| {
+                                    state.optional(|state| { state.match_string("\0") })
+                                })
+                                .and_then(|state| { super::hidden::skip(state) })
+                                .and_then(|state| { self::r#EOI(state) })
+                        })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#base_macro(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#base_macro,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .match_string("#base")
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| {
+                                                self::r#quoted_raw_string(state)
+                                                    .or_else(|state| { self::r#unquoted_string(state) })
+                                            })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#quoted_raw_string(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::CompoundAtomic,
+                            |state| {
+                                state
+                                    .rule(
+                                        Rule::r#quoted_raw_string,
+                                        |state| {
+                                            state
+                                                .sequence(|state| {
+                                                    state
+                                                        .match_string("\"")
+                                                        .and_then(|state| { self::r#quoted_inner(state) })
+                                                        .and_then(|state| { state.match_string("\"") })
+                                                })
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#pairs(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .sequence(|state| {
+                            state
+                                .optional(|state| {
+                                    self::r#pair(state)
+                                        .and_then(|state| {
+                                            state
+                                                .repeat(|state| {
+                                                    state
+                                                        .sequence(|state| {
+                                                            super::hidden::skip(state)
+                                                                .and_then(|state| { self::r#pair(state) })
+                                                        })
+                                                })
+                                        })
+                                })
+                        })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#pair(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#pair,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        self::r#key(state)
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { self::r#value(state) })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#key(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    self::r#quoted_string(state)
+                        .or_else(|state| { self::r#unquoted_string(state) })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#value(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    self::r#quoted_string(state)
+                        .or_else(|state| { self::r#obj(state) })
+                        .or_else(|state| { self::r#unquoted_string(state) })
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#obj(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#obj,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .match_string("{")
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { self::r#pairs(state) })
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { state.match_string("}") })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#quoted_string(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .atomic(
+                            ::pest::Atomicity::CompoundAtomic,
+                            |state| {
+                                state
+                                    .rule(
+                                        Rule::r#quoted_string,
+                                        |state| {
+                                            state
+                                                .sequence(|state| {
+                                                    state
+                                                        .match_string("\"")
+                                                        .and_then(|state| { self::r#quoted_inner(state) })
+                                                        .and_then(|state| { state.match_string("\"") })
+                                                })
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#quoted_inner(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#quoted_inner,
+                            |state| {
+                                state
+                                    .atomic(
+                                        ::pest::Atomicity::Atomic,
+                                        |state| {
+                                            let strings = ["\""];
+                                            state.skip_until(&strings)
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#unquoted_string(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#unquoted_string,
+                            |state| {
+                                state
+                                    .atomic(
+                                        ::pest::Atomicity::Atomic,
+                                        |state| {
+                                            state
+                                                .sequence(|state| {
+                                                    self::r#unquoted_char(state)
+                                                        .and_then(|state| {
+                                                            state.repeat(|state| { self::r#unquoted_char(state) })
+                                                        })
+                                                })
+                                        },
+                                    )
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(non_snake_case, unused_variables)]
+                pub fn r#unquoted_char(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state
+                        .rule(
+                            Rule::r#unquoted_char,
+                            |state| {
+                                state
+                                    .sequence(|state| {
+                                        state
+                                            .lookahead(
+                                                false,
+                                                |state| {
+                                                    state
+                                                        .match_string("\"")
+                                                        .or_else(|state| { state.match_string("{") })
+                                                        .or_else(|state| { state.match_string("}") })
+                                                        .or_else(|state| { self::r#WHITESPACE(state) })
+                                                },
+                                            )
+                                            .and_then(|state| { super::hidden::skip(state) })
+                                            .and_then(|state| { self::r#ANY(state) })
+                                    })
+                            },
+                        )
+                }
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn ANY(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state.skip(1)
+                }
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn EOI(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state.rule(Rule::EOI, |state| state.end_of_input())
+                }
+                #[inline]
+                #[allow(dead_code, non_snake_case, unused_variables)]
+                pub fn SOI(
+                    state: ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                ) -> ::pest::ParseResult<
+                    ::std::boxed::Box<::pest::ParserState<'_, Rule>>,
+                > {
+                    state.start_of_input()
+                }
+            }
+            pub use self::visible::*;
+        }
+        ::pest::state(
+            input,
+            |state| {
+                match rule {
+                    Rule::r#WHITESPACE => rules::r#WHITESPACE(state),
+                    Rule::r#COMMENT => rules::r#COMMENT(state),
+                    Rule::r#vdf => rules::r#vdf(state),
+                    Rule::r#base_macro => rules::r#base_macro(state),
+                    Rule::r#quoted_raw_string => rules::r#quoted_raw_string(state),
+                    Rule::r#pairs => rules::r#pairs(state),
+                    Rule::r#pair => rules::r#pair(state),
+                    Rule::r#key => rules::r#key(state),
+                    Rule::r#value => rules::r#value(state),
+                    Rule::r#obj => rules::r#obj(state),
+                    Rule::r#quoted_string => rules::r#quoted_string(state),
+                    Rule::r#quoted_inner => rules::r#quoted_inner(state),
+                    Rule::r#unquoted_string => rules::r#unquoted_string(state),
+                    Rule::r#unquoted_char => rules::r#unquoted_char(state),
+                    Rule::EOI => rules::EOI(state),
+                }
+            },
+        )
+    }
+}

--- a/keyvalues-parser/tests/grammar_generator/mod.rs
+++ b/keyvalues-parser/tests/grammar_generator/mod.rs
@@ -1,0 +1,99 @@
+//! Handles generating the parsers from the grammar files
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use pest_generator::derive_parser;
+use quote::quote;
+use syn::Item;
+
+#[test]
+fn escaped() {
+    snapshot_or_update_parser(Parser::Escaped);
+}
+
+#[test]
+fn raw() {
+    snapshot_or_update_parser(Parser::Raw);
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Parser {
+    Escaped,
+    Raw,
+}
+
+impl Parser {
+    fn grammar_path(self) -> &'static str {
+        match self {
+            Self::Escaped => "grammars/escaped.pest",
+            Self::Raw => "grammars/raw.pest",
+        }
+    }
+
+    fn parser_path(self) -> PathBuf {
+        Path::new("src")
+            .join("text")
+            .join("parse")
+            .join(match self {
+                Self::Escaped => "escaped.rs",
+                Self::Raw => "raw.rs",
+            })
+    }
+}
+
+#[track_caller]
+fn snapshot_or_update_parser(parser: Parser) {
+    let parser_file = generate_file(parser);
+
+    if env::var_os("UPDATE_PARSERS").is_some() {
+        fs::write(parser.parser_path(), parser_file).unwrap();
+    } else {
+        // otherwise we check the output against the existing parser
+        let existing_file = fs::read_to_string(parser.parser_path()).unwrap();
+        if parser_file != existing_file {
+            panic!(
+                "existing parser is out of sync! update the parsers by running the test suite with \
+                the env var `UPDATE_PARSERS` set to anything"
+            );
+        }
+    }
+}
+
+#[track_caller]
+fn generate_file(parser: Parser) -> String {
+    let grammar_path = parser.grammar_path();
+    let derive_tokens = quote! {
+        #[grammar = #grammar_path]
+        struct Parser;
+    };
+    let expanded_tokens = derive_parser(derive_tokens.clone(), false);
+    let is_escaped = parser == Parser::Escaped;
+    let file = quote! {
+        use super::*;
+        use pest::Parser as _;
+        pub type PestError = pest::error::Error<Rule>;
+        struct Parser;
+        crate::common_parsing!(Parser, Rule, #is_escaped);
+        #expanded_tokens
+    };
+    let mut file = syn::parse_file(&file.to_string()).unwrap();
+    cleanup_file(&mut file);
+    let formatted = prettyplease::unparse(&file);
+    format!(
+        "// !!GENERATED CODE!! DO NOT EDIT MANUALLY. edit through the `grammar_generator` tests\n\
+        {formatted}"
+    )
+}
+
+fn cleanup_file(file: &mut syn::File) {
+    file.items.retain_mut(|mut item| match &mut item {
+        // `pest` includes the grammar with an absolute file path. at the very least the path
+        // would need to be normalized, but the grammar doesn't seem to actually be used for
+        // anything
+        Item::Const(c) => !c.ident.to_string().starts_with("_PEST_GRAMMAR"),
+        _ => true,
+    });
+}

--- a/keyvalues-parser/tests/stub.rs
+++ b/keyvalues-parser/tests/stub.rs
@@ -1,3 +1,4 @@
+mod grammar_generator;
 mod regressions;
 mod text_parser;
 mod vdf_iteration;


### PR DESCRIPTION
`pest_derive` is actually a tiny layer over `pest_generator` which we can use to generate the parser code ahead of time. This drops the need to depend on `pest_derive` (and its macro-heavy dependencies :smiling_imp:)